### PR TITLE
Priorities for the tasks

### DIFF
--- a/dist/types/sequential-task-queue.d.ts
+++ b/dist/types/sequential-task-queue.d.ts
@@ -27,6 +27,10 @@ export interface SequentialTaskQueueOptions {
      * Scheduler used by the queue. Defaults to {@link SequentialTaskQueue.defaultScheduler}.
      */
     scheduler?: Scheduler;
+    /**
+     * Default priority of the task. Task with the lower value gets executed first.
+     * */
+    priority?: number;
 }
 /**
  * Options object for individual tasks.
@@ -49,6 +53,10 @@ export interface TaskOptions {
      * }
      */
     args?: any;
+    /**
+     * Priority of the task. Task with the lower value gets executed first.
+     * */
+    priority?: number;
 }
 /**
  * Provides the API for querying and invoking task cancellation.
@@ -107,6 +115,7 @@ export declare class SequentialTaskQueue {
     private currentTask;
     private scheduler;
     private events;
+    private defaultPriority;
     name: string;
     /** Indicates if the queue has been closed. Calling {@link SequentialTaskQueue.push} on a closed queue will result in an exception. */
     readonly isClosed: boolean;


### PR DESCRIPTION
Argument `options` of method `push()` now has `priority` field.  Task with the lower value gets executed first.

Simple test:
```javascript
const SequentialTaskQueue = require('sequential-task-queue').SequentialTaskQueue;

function job(n, pr) {
    return new Promise(res => {
        setTimeout(()=>{
            console.log(`Task ${n} is finished with priority ${pr}.`);
            res();
        }, Math.random()*2000);
    });
}

const queue = new SequentialTaskQueue({priority: 0});
for(let i = 0; i < 20; ++i) {
    let pr = (Math.random()*100).toFixed(0);
    queue.push(async () => {
        await job(i, pr);
    }, {priority: pr});
}

setTimeout(() => {
    let pr = -10;
    queue.push(async () => {
        await job(999, pr);
    }, {priority: pr});
    console.log("High priority job added");
},4000);

```